### PR TITLE
Add alias for php artisan command in php Dockerfile

### DIFF
--- a/larado/php/dockerfile
+++ b/larado/php/dockerfile
@@ -19,6 +19,8 @@ RUN mkdir -p /var/www/.composer
 RUN chmod -R 755 /var/www/.composer
 RUN chown -R www-data:www-data /var/www/.composer
 
+RUN echo "alias pa='php artisan'" >> ~/.bashrc
+
 # you can add php config 👇
 # RUN echo "memory_limit = 2048M" > $PHP_INI_DIR/conf.d/config.ini
 

--- a/larado/php/dockerfile
+++ b/larado/php/dockerfile
@@ -19,7 +19,7 @@ RUN mkdir -p /var/www/.composer
 RUN chmod -R 755 /var/www/.composer
 RUN chown -R www-data:www-data /var/www/.composer
 
-RUN echo "alias pa='php artisan'" >> ~/.bashrc
+RUN echo "alias pa='php artisan'" >> /etc/bash.bashrc
 
 # you can add php config 👇
 # RUN echo "memory_limit = 2048M" > $PHP_INI_DIR/conf.d/config.ini


### PR DESCRIPTION
This PR introduces alias pa  for the php artisan command in the Docker container by adding them to the ~/.bashrc file. 

These aliases simplify the usage of php artisan commands, making it quicker and easier to execute Laravel Artisan commands during development and debugging within the container.

Benefits:

- Shorter and more efficient command usage.
- Improved developer experience when interacting with the container shell.