### PR TITLE
Add xdebug for development environment

### DIFF
--- a/docker-compose-common.yml
+++ b/docker-compose-common.yml
@@ -1,7 +1,9 @@
 services:
     laravel:
         container_name: "${APP_NAME:-larado}-laravel"
-        build: "./larado/php"
+        build:
+            context: ./larado/php
+            dockerfile: dockerfile
         image: "larado-${APP_NAME:-project}-laravel"
         restart: unless-stopped
         volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,13 @@ services:
         extends:
             file: docker-compose-common.yml
             service: laravel
+        build:
+            context: ./larado/php
+            dockerfile: dockerfile-dev
+        environment:
+            XDEBUG_MODE: "develop,debug"
+            XDEBUG_START: "yes"
+            XDEBUG_CLIENT_HOST: "host.docker.internal"
         ports:
             - "80:80"
             # - "8000:8000"

--- a/larado/php/dockerfile-dev
+++ b/larado/php/dockerfile-dev
@@ -1,0 +1,35 @@
+FROM mnr73/larado
+
+# Install Xdebug via PECL
+RUN set -eux; \
+    pecl install xdebug; \
+    docker-php-ext-enable xdebug
+
+COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
+COPY 000-default.conf /etc/apache2/sites-available
+
+# scheduler
+RUN echo "* * * * * www-data /usr/local/bin/php /var/www/html/artisan schedule:run >> /dev/null 2>&1" > /etc/cron.d/scheduler
+RUN chmod 0644 /etc/cron.d/scheduler \
+    && crontab /etc/cron.d/scheduler
+
+COPY start-container /usr/local/bin/start-container
+RUN chmod +x /usr/local/bin/start-container
+
+RUN mkdir -p /var/www/.config/psysh
+RUN chmod -R 755 /var/www/.config
+RUN chown -R www-data:www-data /var/www/.config
+
+RUN mkdir -p /var/www/.composer
+RUN chmod -R 755 /var/www/.composer
+RUN chown -R www-data:www-data /var/www/.composer
+
+RUN echo "alias pa='php artisan'" >> /etc/bash.bashrc
+
+# you can add php config 👇
+# RUN echo "memory_limit = 2048M" > $PHP_INI_DIR/conf.d/config.ini
+
+# Xdebug config (minimal; behavior via env)
+COPY xdebug.ini /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
+
+ENTRYPOINT ["start-container"]

--- a/larado/php/xdebug.ini
+++ b/larado/php/xdebug.ini
@@ -1,0 +1,17 @@
+zend_extension=xdebug
+
+; Keep Xdebug OFF unless you explicitly enable modes via env
+xdebug.mode=${XDEBUG_MODE}
+; trigger or yes
+xdebug.start_with_request=${XDEBUG_START}
+
+xdebug.idekey=docker
+
+; IDE host: on mac/win use host.docker.internal; on Linux use gateway IP (see note below)
+xdebug.client_host=${XDEBUG_CLIENT_HOST}
+xdebug.client_port=9003
+xdebug.discover_client_host=1
+
+; Less noise (set to 7 for troubleshooting)
+xdebug.log_level=0
+xdebug.log=/dev/stdout


### PR DESCRIPTION
This commit adds a new Dockerfile named dockerfile-dev for use in the local development environment.

The dockerfile-dev installs Xdebug and copies the xdebug.ini file into the PHP extensions directory.

Additionally, docker-compose-common.yml is updated to set the build context to the default production-ready Dockerfile, while docker-compose.yml overrides it to use the new development Dockerfile.